### PR TITLE
Arch package is orphaned and should not be used

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,9 +58,6 @@ If you would prefer to install the CLI from source, the following will work:
   ``pipx install instawow``
 - Vanilla pip:
   ``python -m pip install -U instawow``
-- From the `AUR <https://aur.archlinux.org/packages/instawow/>`__
-  for Arch Linux:
-  ``yay -S instawow``
 
 When installing from source, *instawow* requires Python 3.7 or greater.
 


### PR DESCRIPTION
Hi @layday,

Due to multiple factos some personal and another one being my Linux computer is broken, I am unable to maintain this package anymore for Arch Linux and am removing the mention until someone takes it over.

Regards,
Kevin