### PR TITLE
Fix list format flag not working

### DIFF
--- a/src/instawow/cli/__init__.py
+++ b/src/instawow/cli/__init__.py
@@ -268,9 +268,9 @@ def _make_pkg_where_clause_and_params(
 
 
 class _ListFormat(enum.StrEnum):
-    Simple = enum.auto()
-    Detailed = enum.auto()
-    Json = enum.auto()
+    Simple = 'Simple'
+    Detailed = 'Detailed'
+    Json = 'Json'
 
 
 @click.group(context_settings={'help_option_names': ('-h', '--help')}, cls=SectionedHelpGroup)


### PR DESCRIPTION
Replace the `auto()` values by string values matching the `--help` documentation.

close #195 